### PR TITLE
[#76] Service validate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,16 +35,15 @@ MAINTAINER 5GTANGO
 
 # install git
 RUN apk update && apk upgrade && apk add --no-cache bash git && apk add --update redis
-
 RUN pip install pycodestyle
 
 # install tng-sdk-project first
 #WORKDIR /opt
 RUN git clone https://github.com/sonata-nfv/tng-sdk-project.git
 WORKDIR tng-sdk-project
-RUN ls -hall
 #RUN pip install -r requirements.txt
 RUN python setup.py install
+RUN tng-workspace
 
 ADD . /tng-sdk-validation
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
     stage('Unit Tests') {
       steps {
         echo 'Unit Testing..'
+	sh "docker network ls | grep redis_network && docker network rm redis_network"
         sh "docker network create --driver bridge redis_network"
         sh "docker run -d --name redis_docker -p 6379:6379 --network redis_network redis"
         sh "docker run --network redis_network -e VAPI_REDIS_HOST='redis_docker' -i --rm registry.sonata-nfv.eu:5000/tng-sdk-validation pytest -v --ignore=src/tngsdk/validation/gui/"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,10 @@ pipeline {
     stage('Unit Tests') {
       steps {
         echo 'Unit Testing..'
-	sh "docker network ls | grep redis_network && docker network rm redis_network"
+        sh "docker info"
+	      sh "docker container ls -a"
+        sh "docker network ls -a"
+        sh "docker network ls | grep redis_network && docker network rm redis_network"
         sh "docker network create --driver bridge redis_network"
         sh "docker run -d --name redis_docker -p 6379:6379 --network redis_network redis"
         sh "docker run --network redis_network -e VAPI_REDIS_HOST='redis_docker' -i --rm registry.sonata-nfv.eu:5000/tng-sdk-validation pytest -v --ignore=src/tngsdk/validation/gui/"
@@ -53,4 +56,3 @@ pipeline {
     }
   }
 }
-

--- a/src/tngsdk/validation/__init__.py
+++ b/src/tngsdk/validation/__init__.py
@@ -48,7 +48,6 @@ def logging_setup():
 def main():
     logging_setup()
     args = cli.parse_args()
-
     # TODO better log configuration (e.g. file-based logging)
     if args.verbose:
         coloredlogs.install(level="DEBUG")

--- a/src/tngsdk/validation/cli.py
+++ b/src/tngsdk/validation/cli.py
@@ -61,6 +61,8 @@ def dispatch(args, validator):
             validator.configure(syntax=True, integrity=True, topology=True,
                                 custom=True, cfile=args.cfile)
             print("Syntax, integrity, topology  and custom rules validation")
+        else:
+            print("Default mode: Syntax, integrity and topology validation")
         if validator.validate_function(args.vnfd):
             if validator.error_count == 0:
                 if len(validator.customErrors) == 0:
@@ -87,13 +89,17 @@ def dispatch(args, validator):
                                 custom=True, cfile=args.cfile,
                                 dpath=args.dpath)
             print("Syntax, integrity, topology  and custom rules validation")
+        else:
+            validator.configure(syntax=True, integrity=True, topology=True,
+                                dpath=args.dpath)
+            print("Default mode: Syntax, integrity and topology validation")
 
-        validator.validate_service(args.nsd)
-        if validator.error_count == 0:
-            if len(validator.customErrors) == 0:
-                print("No errors found in the Service validation")
-            else:
-                print("Errors in custom rules validation")
+        if validator.validate_service(args.nsd):
+            if validator.error_count == 0:
+                if len(validator.customErrors) == 0:
+                    print("No errors found in the Service validation")
+                else:
+                    print("Errors in custom rules validation")
         return validator
 
     elif args.project_path:
@@ -115,7 +121,8 @@ def dispatch(args, validator):
             validator.configure(syntax=True, integrity=True, topology=True,
                                 custom=True, cfile=args.cfile)
             print("Syntax, integrity, topology  and custom rules validation")
-
+        else:
+            print("Default mode: Syntax, integrity and topology validation")
         if not validator.validate_project(args.project_path):
             print('Cant validate the project')
         else:
@@ -130,6 +137,15 @@ def dispatch(args, validator):
 
 def check_args(args):
     if (args.nsd):
+        if (not(args.integrity) and not(args.syntax) and not(args.topology) and not(args.custom)):
+            if (args.dpath and args.dext):
+                return True
+            else:
+                print("Invalid parameters. To validate the "
+                      "integrity, topology or custom rules of a service "
+                      "both' --dpath' and '--dext' parameters must be "
+                      "specified.")
+                return False
         if (args.integrity or args.topology):
             if (args.dpath and args.dext):
                 return True
@@ -139,7 +155,8 @@ def check_args(args):
                       "both' --dpath' and '--dext' parameters must be "
                       "specified.")
                 return False
-        if (args.custom):
+
+        elif (args.custom):
             if (args.dpath and args.dext and args.cfile):
                 return True
             else:
@@ -149,7 +166,7 @@ def check_args(args):
                       "specified (to validate the topology/integrity) and "
                       "'--cfile' must be specified")
                 return False
-    if (args.vnfd):
+    elif (args.vnfd):
         if (args.custom):
             if (args.cfile):
                 return True
@@ -316,11 +333,6 @@ def parse_args(input_args=None):
         dest="service_port"
     )
 
-    if input_args is None:
-        if (len(sys.argv) == 1):
-            input_args = ["-t"]
-            print("Default mode: -t")
-        else:
-            input_args = sys.argv[1:]
-            print("CLI input arguments: {}".format(input_args))
+    input_args = sys.argv[1:]
+    print("CLI input arguments: {}".format(input_args))
     return parser.parse_args(input_args)

--- a/src/tngsdk/validation/storage.py
+++ b/src/tngsdk/validation/storage.py
@@ -626,6 +626,7 @@ class Service(Descriptor):
         """
         Initialize a service object. This inherits the descriptor object.
         :param descriptor_file: descriptor filename
+        :param _functions:
         """
         super().__init__(descriptor_file)
         self._functions = {}
@@ -639,7 +640,6 @@ class Service(Descriptor):
         :return: functions dict
         """
         return self._functions
-
     @property
     def fw_graphs(self):
         """
@@ -1130,7 +1130,7 @@ class Function(Descriptor):
             for cdu in self.content['cloudnative_deployment_units']:
                 unit = Unit(cdu['id'])
                 self.associate_unit(unit)
-                # TODO check if image exists as with the VNF 
+                # TODO check if image exists as with the VNF
             return True
 
         else:

--- a/src/tngsdk/validation/util.py
+++ b/src/tngsdk/validation/util.py
@@ -91,7 +91,6 @@ def read_descriptor_file(file):
 
         return descriptor
 
-
 def descriptor_id(descriptor):
     """
     Provides the descriptor id of the specified descriptor content

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -350,12 +350,11 @@ class Validator(object):
         Validate a 5GTANGO service.
         By default, it performs the following validations: syntax, integrity
         and network topology.
-        :param nsd_file: service descriptor filename
+        :param nsd_file: service descriptor path
         :return: True if all validations were successful, False otherwise
         """
         if not self._assert_configuration():
             return
-
         log.info("Validating service '{0}'".format(nsd_file))
         log.info("... syntax: {0}, integrity: {1}, topology: {2}"
                  .format(self._syntax, self._integrity, self._topology))
@@ -685,7 +684,6 @@ class Validator(object):
                            service.id,
                            'evt_nsd_itg_function_invalid')
                 return
-
         # load service connection points
         if not service.load_connection_points():
             evtlog.log("Bad section 'connection_points'",
@@ -695,7 +693,6 @@ class Validator(object):
                        service.id,
                        'evt_nsd_itg_badsection_cpoints')
             return
-
         # load service links
         if not service.load_virtual_links():
             evtlog.log("Bad section 'virtual_links'",
@@ -704,7 +701,6 @@ class Validator(object):
                        service.id,
                        'evt_nsd_itg_badsection_vlinks')
             return
-
         undeclared = service.undeclared_connection_points()
         if undeclared:
             for cxpoint in undeclared:
@@ -715,7 +711,6 @@ class Validator(object):
                            service.id,
                            'evt_nsd_itg_undeclared_cpoint')
             return
-
         # check for unused connection points
         unused_ifaces = service.unused_connection_points()
         if unused_ifaces:
@@ -752,6 +747,7 @@ class Validator(object):
                         return
         return True
 
+
     def _load_service_functions(self, service):
         """
         Loads and stores functions (VNFs) referenced in the specified service
@@ -767,7 +763,6 @@ class Validator(object):
             vnfd_files = list(self._dpath)
         else:
             vnfd_files = list_files(self._dpath, self._dext)
-
             log.debug("Found {0} descriptors in dpath='{2}': {1}"
                       .format(len(vnfd_files), vnfd_files, self._dpath))
 
@@ -827,7 +822,6 @@ class Validator(object):
             log.info("Validating functions in path '{0}'".format(vnfd_path))
             vnfd_files = list_files(vnfd_path, self._dext)
             # ANTON
-            print(*vnfd_files, sep='\n')
             for vnfd_file in vnfd_files:
                 log.info("Detected file {0} order validation..."
                          .format(vnfd_file))

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -918,7 +918,7 @@ class Validator(object):
 
         # load units
         if not func.load_units():
-            evtlog.log("Missing 'virtual_deployment_units'",
+            evtlog.log("Missing 'virtual_deployment_units or cloudnative_deployment_units'",
                        "Couldn't load the units of function id='{0}'"
                        .format(func.id),
                        func.id,


### PR DESCRIPTION
`tng-validate --service path/to/example_nsd --dpath path/to/function_folder/ --dext <extension>` works using -s, -i, -t or nothing which implies -t validation. Also, `tng-validate -s --service path/to/example_nsd works`.