### PR TITLE
Test descriptor validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ python3 setup.py install
 
 ### CLI mode
 
-The CLI interface is designed for developer usage, allowing to quickly validate SDK projects,package descriptors, service descriptors and function descriptors. The different levels of validation, namely syntax, integrity and topology can only be used in the following combinations:
+The CLI interface is designed for developer usage, allowing to quickly validate SDK projects descriptors, package descriptors, service descriptors and function descriptors. The different levels of validation are syntax, integrity, topology and custom_rules. They can only be used in the following combinations:
 
 * syntax only: `-s` or `--syntax`
 * syntax and integrity `-i` or `--integrity`
@@ -46,27 +46,22 @@ The CLI interface is designed for developer usage, allowing to quickly validate 
 * syntax, integrity, topology and custom_rules `-c` or `--custom`
 
 The tng-sdk-validation CLI tool can be used to validate one of the following components:
-`-project` - to validate an SDK project, the `--workspace` parameter must be specified, otherwise the default location `$ HOME/.tng-workspace` is assumed. (still working in this validations)
-* service - in service validation, if the chosen level of validation comprises more than syntax (integrity or topology), the `--dpath` argument must be specified in order to indicate the location of the VNF descriptor files, referenced in the service (this mustn't be specified in syntax validation). Has a standalone validation of a service, son-validate is not aware of a directory structure, unlike the project validation.
-  Moreover, the `--dext` parameter should also be specified to indicate the extension of descriptor files.
-* function - this specifies the validation of an individual VNF. It is also possible to validate multiple functions in bulk contained inside a directory. To if the `--function` is a directory, it will search for descriptor files with the extension specified by parameter `--dext`.
+
+* `--project` - If this option is chosen, all descriptors in the project will be validated. It is possible to use `--workspace`/`-w` parameter to set a particular workspace path, otherwise, the path is `$ HOME/.tng-workspace`.
+
+* `--service` - It is possible validate only the syntax of the service descriptor in the case of use `--syntax`. If a superior validation is chosen (for instance integrity), it is necessary to specify `--dpath` and `--dext` parameters. Using the superior validation the functions referenced by the descriptor will be validated too.
+
+* `--function` - There are two modes of function descriptor validation, validate an individual function descriptor or validation of all descriptors inside a directory.
 
 ```
-5gtango@validation-host:# tng-sdk-validate -h
-CLI input arguments: []
-usage: tng-sdk-validate [-h] [-w WORKSPACE_PATH]
-                        (--project PROJECT_PATH | --service NSD | --function VNFD | --api)
-                        [--dpath DPATH] [--dext DEXT] [--syntax] [--integrity]
-                        [--topology] [--debug] [--mode {stateless,local}]
-                        [--host SERVICE_ADDRESS] [--port SERVICE_PORT]
-tng-sdk-validate: error: one of the arguments --project --package --service --function --api is required
-root@debian-experiment:/home/quobis/tng-sdk-validation/src/tngsdk/validation/tests# tng-sdk-validate -h
+quobis@quobis-UX303UA:~/tng-sdk-validation$ tng-sdk-validate -h
 CLI input arguments: ['-h']
-usage: tng-sdk-validate [-h] [-w WORKSPACE_PATH]
-                        (--project PROJECT_PATH | --service NSD | --function VNFD | --api)
-                        [--dpath DPATH] [--dext DEXT] [--syntax] [--integrity]
-                        [--topology] [--debug] [--mode {stateless,local}]
-                        [--host SERVICE_ADDRESS] [--port SERVICE_PORT]
+usage: tng-validate [-h] [-w WORKSPACE_PATH]
+                    (--project PROJECT_PATH | --package PACKAGE_FILE | --service NSD | --function VNFD | --api)
+                    [--dpath DPATH] [--dext DEXT] [--syntax] [--integrity]
+                    [--topology] [--custom] [--cfile CFILE] [--debug]
+                    [--mode {stateless,local}] [--host SERVICE_ADDRESS]
+                    [--port SERVICE_PORT]
 
 5GTANGO SDK validator
 
@@ -77,11 +72,13 @@ optional arguments:
                         validating the SDK project.
   --project PROJECT_PATH
                         Validate the service of the specified SDK project.
+  --package PACKAGE_FILE
+                        Validate the specified package descriptor.
   --service NSD         Validate the specified service descriptor. The
                         directory of descriptors referenced in the service
                         descriptor should be specified using the argument '--
                         path'.
-  --function VNFD       Validate the specified function descriptor. If a
+  --function VNFD/CNFD  Validate the specified function descriptor. If a
                         directory is specified, it will search for descriptor
                         files with extension defined in '--dext'
   --api                 Run validator in service mode with REST API.
@@ -91,11 +88,11 @@ optional arguments:
   --dext DEXT           Specify the extension of descriptor files.
                         Particularly useful when using the '--function'
                         argument
-  --cfile               Specify the rules used to validate.
   --syntax, -s          Perform a syntax validation.
   --integrity, -i       Perform an integrity validation.
   --topology, -t        Perform a network topology validation.
-  --custom, -c          Perform a custom rules validation.
+  --custom, -c          Perform a network custom rules validation.
+  --cfile CFILE         Specify the file with the custom rules to validate
   --debug               Sets verbosity level to debug
   --mode {stateless,local}
                         Specify the mode of operation. 'stateless' mode will
@@ -109,16 +106,29 @@ optional arguments:
   --port SERVICE_PORT   Bind port number
 
 Example usage:
-        tng-sdk-validate --project /home/sonata/projects/project_X
-                     --workspace /home/sonata/.son-workspace
-        tng-sdk-validate --service ./nsd_file.yml --path ./vnfds/ --dext yml
-        tng-sdk-validate --function ./vnfd_file.yml
-        tng-sdk-validate --function ./vnfds/ --dext yml
+
+    - Validation of project descriptors in a particular workspace.
+        tng-sdk-validate --project path/to/project/ --workspace path/to/workspace
+
+    - Validation of project descriptors in the default workspace ($ HOME/.tng-workspace).
+        tng-sdk-validate --project path/to/project/
+
+    - Validation of service descriptors.
+        tng-sdk-validate  --service path/to/example_nsd.yml --dpath path/to/function_folder --dext yml
+
+    - Validation of all function (VNF/CNF) descriptors in a folder.
+        tng-sdk-validate --function path/to/function_folder/
+        tng-sdk-validate --function path/to/function_folder/ --dext yml
+
+    - Validation of individual function (VNF/CNF) descriptor.
+        tng-sdk-validate --function path/to/example_function.yml
+        tng-sdk-validate --function path/to/example_function.yml --dext yml
+
 ```
 
 ## Documentation
 
-Please refer to the [wiki](https://github.com/sonata-nfv/tng-sdk-validation/wiki) of the project for a more detailed documentation. 
+Please refer to the [wiki](https://github.com/sonata-nfv/tng-sdk-validation/wiki) of the project for a more detailed documentation.
 
 ## License
 

--- a/src/tngsdk/validation/cli.py
+++ b/src/tngsdk/validation/cli.py
@@ -66,7 +66,6 @@ def dispatch(args, validator):
             print("Syntax, integrity, topology  and custom rules validation")
         else:
             print("Default mode: Syntax, integrity and topology validation")
-
         if validator.validate_function(args.vnfd):
             if ((validator.error_count == 0) and (len(validator.customErrors) == 0)):
                 print("No errors found in the VNFD")
@@ -144,8 +143,8 @@ def dispatch(args, validator):
             print("Integrity validation")
             validator.configure(syntax=True, integrity=True, topology=False, custom=False)
         else:
-            print("Default test descriptor validation, syntax and integrity")
-            validator.configure(syntax=True, integrity=False, topology=False, custom=False)
+            print("Default test descriptor validation syntax and integrity")
+            validator.configure(syntax=True, integrity=True, topology=False, custom=False)
 
     if not validator.validate_test(args.tstd):
         print('Cant validate the test descriptors')

--- a/src/tngsdk/validation/cli.py
+++ b/src/tngsdk/validation/cli.py
@@ -72,7 +72,7 @@ def dispatch(args, validator):
             if ((validator.error_count == 0) and (len(validator.customErrors) == 0)):
                 print("No errors found in the VNFD")
             else:
-                print("Errors in custom rules validation")
+                print("Errors in validation")
         return validator
 
     elif args.nsd:

--- a/src/tngsdk/validation/eventcfg.yml
+++ b/src/tngsdk/validation/eventcfg.yml
@@ -141,8 +141,8 @@ evt_vnfd_top_isolated_units: error
 
 # VNFD [topology] - loops were detected
 evt_vnfd_top_loops: error
-
-
+# VNFD [topology] - cycles were detected
+evt_vnfd_top_cycles: error
 ## TEST
 # Test - invalid descriptor file
 evt_test_invalid_descriptor: error

--- a/src/tngsdk/validation/eventcfg.yml
+++ b/src/tngsdk/validation/eventcfg.yml
@@ -136,6 +136,13 @@ evt_vnfd_itg_undefined_cpoint: error
 # VNFD [topology] - failed to build topology graph
 evt_vnfd_top_topgraph_failed: error
 
+# VNFD [topology] - isolated units were detected
+evt_vnfd_top_isolated_units: error
+
+# VNFD [topology] - loops were detected
+evt_vnfd_top_loops: error
+
+
 ## TEST
 # Test - invalid descriptor file
 evt_test_invalid_descriptor: error

--- a/src/tngsdk/validation/eventcfg.yml
+++ b/src/tngsdk/validation/eventcfg.yml
@@ -136,7 +136,42 @@ evt_vnfd_itg_undefined_cpoint: error
 # VNFD [topology] - failed to build topology graph
 evt_vnfd_top_topgraph_failed: error
 
+## TEST
+# Test - invalid descriptor file
+evt_test_invalid_descriptor: error
 
+# TSTD [syntax] - invalid schema syntax
+evt_tstd_stx_invalid: error
+
+# TSTD [integrity] - test_type missing
+evt_tstd_itg_badsection_test_type: error
+
+# TSTD [integrity] - test_configuration_parameters missing
+evt_tstd_itg_badsection_test_configuration_parameters: error
+
+# TSTD [integrity] - test_category missing
+evt_tstd_itg_badsection_test_category: error
+
+# TSTD [integrity] - test_configuration_parameters_parameter_name missing
+evt_tstd_itg_badsection_test_configuration_parameters_parameter_name: error
+
+# TSTD [integrity] - test_configuration_parameters_parameter_name missing
+evt_tstd_itg_badsection_test_configuration_parameters_parameter_definition: error
+
+# TSTD [integrity] - test_configuration_parameters_parameter_name missing
+evt_tstd_itg_badsection_test_configuration_parameters_parameter_value: error
+
+# TSTD [integrity] - test_configuration_parameters_parameter_name missing
+evt_tstd_itg_badsection_test_configuration_parameters_content_type: error
+
+# TSTD [integrity] - test_execution missing
+evt_tstd_itg_badsection_test_execution: error
+
+# TSTD [integrity] - test_execution_test_tag
+evt_tstd_itg_badsection_test_execution_test_tag: error
+
+# TSTD [integrity] - test_execution_test_id
+evt_tstd_itg_badsection_test_execution_test_id: error
 ### GENERAL
 
 # Duplicate declaration of connection point

--- a/src/tngsdk/validation/rest.py
+++ b/src/tngsdk/validation/rest.py
@@ -130,7 +130,7 @@ class Validatewatchers(FileSystemEventHandler):
 
 
 def initialize(debug=False):
-    log.info("Initializing validator service")
+    log.info("Initializing validator service descriptor")
 
     cache.clear()
     cache.add('debug', debug)
@@ -208,18 +208,18 @@ validations_parser.add_argument("function",
                                 location="args",
                                 type=inputs.boolean,
                                 required=False,
-                                help="Function validation")
+                                help="Function descriptor validation")
 validations_parser.add_argument("service",
                                 location="args",
                                 type=inputs.boolean,
                                 required=False,
-                                help="Service validation")
+                                help="Service descriptor validation")
 validations_parser.add_argument("project",
                                 location="args",
                                 type=inputs.boolean,
                                 required=False,
                                 help="If True indicates that the request "
-                                     "if for a project validation")
+                                     "if for a project descriptor validation")
 validations_parser.add_argument("workspace",
                                 location="args",
                                 required=False,
@@ -247,7 +247,7 @@ validations_parser.add_argument("path",
 validations_parser.add_argument("dext",
                                 location="args",
                                 required=False,
-                                help="Specify the extension of the function "
+                                help="Specify the extension of the function descriptor "
                                      "files that are asociated with a service"
                                      " validation.")
 validations_parser.add_argument("cfile",
@@ -569,7 +569,7 @@ def _validate_object(args, path, keypath, obj_type):
                                                 or False))
 
         if args['function']:
-            log.info("Validating Function: {}".format(descriptor_path))
+            log.info("Validating Function descriptor: {}".format(descriptor_path))
             # TODO check if the function is a valid file path
             validator.validate_function(descriptor_path)
     else:
@@ -591,16 +591,16 @@ def _validate_object(args, path, keypath, obj_type):
                             workspace_path=(args['workspace'] or None))
 
         if args['function']:
-            log.info("Validating Function: {}".format(path))
+            log.info("Validating Function descriptor: {}".format(path))
             validator.validate_function(path)
 
         elif args['service']:
-            log.info("Validating Service: {}".format(path))
+            log.info("Validating Service descriptor: {}".format(path))
             # TODO check if the function is a valid file path
             validator.validate_service(path)
 
         elif args['project']:
-            log.info("Validating Project: {}".format(path))
+            log.info("Validating Project descriptor: {}".format(path))
             # TODO check if the function is a valid file path
             validator.validate_project(path)
 
@@ -738,17 +738,17 @@ def _validate_object_watcher(args, path, keypath, obj_type):
                         workspace_path=(args['workspace'] or False))
 
     if obj_type == 'function':
-        log.info("Validating Function: {}".format(path))
+        log.info("Validating Function descriptor: {}".format(path))
         # TODO check if the function is a valid file path
         validator.validate_function(path)
 
     elif obj_type == 'service':
-        log.info("Validating Service: {}".format(path))
+        log.info("Validating Service descriptor: {}".format(path))
         # TODO check if the function is a valid file path
         validator.validate_service(path)
 
     elif obj_type == 'project':
-        log.info("Validating Project: {}".format(path))
+        log.info("Validating Project descriptor: {}".format(path))
         # TODO check if the function is a valid file path
         validator.validate_project(path)
 
@@ -843,17 +843,17 @@ def _validate_object_from_watch(path):
                             custom=(watch['custom'] or False))
 
         if watch['type'] == 'function':
-            log.info("Validating Function: {}".format(path))
+            log.info("Validating Function descriptor: {}".format(path))
             # TODO check if the function is a valid file path
             validator.validate_function(path)
 
         elif watch['type'] == 'service':
-            log.info("Validating Service: {}".format(path))
+            log.info("Validating Service descriptor: {}".format(path))
             # TODO check if the function is a valid file path
             validator.validate_service(path)
 
         elif watch['type'] == 'project':
-            log.info("Validating Project: {}".format(path))
+            log.info("Validating Project descriptor: {}".format(path))
             # TODO check if the function is a valid file path
             validator.validate_project(path)
 
@@ -1041,7 +1041,7 @@ def set_validation(vid, rid, path, obj_type, syntax, integrity, topology,
         validations[vid]['resources']['nsd'] = {'id': '/resources/' + rid,
                                                 'hashFile': hashFile}
         if (syntax and not integrity and not topology and not custom):
-            log.info('Not vnfds in service syntax validation')
+            log.info('Not vnfds in service descriptor syntax validation')
         else:
             vnfds = get_service_validation_resources(dpath)
             validations[vid]['resources']['vnfd'] = []
@@ -1240,22 +1240,22 @@ def check_args(args):
                 "and project parameters"}, 400
 
     if (args.function and args.service):
-        log.info("Not possible to validate function and service in the" +
+        log.info("Not possible to validate function descriptor and service descriptor in the" +
                  " same request")
-        return {"error_message": "Not possible to validate function" +
-                " and service and project in the same request"}, 400
+        return {"error_message": "Not possible to validate function descriptor" +
+                " and service descriptor and project descriptor in the same request"}, 400
 
     if (args.function and args.project):
-        log.info("Not possible to validate function and project in the" +
+        log.info("Not possible to validate function descriptor and project descriptor in the" +
                  " same request")
-        return {"error_message": "Not possible to validate function" +
-                " and project in the same request"}, 400
+        return {"error_message": "Not possible to validate function descriptor" +
+                " and project descriptor in the same request"}, 400
 
     if (args.service and args.project):
-        log.info("Not possible to validate service and project in the" +
+        log.info("Not possible to validate service descriptor and project descriptor in the" +
                  " same request")
-        return {"error_message": "Not possible to validate service" +
-                " and project in the same request"}, 400
+        return {"error_message": "Not possible to validate service descriptor" +
+                " and project descriptor in the same request"}, 400
 
     if (args.source == 'local' or args.source == 'url'):
         if (args.path is None):
@@ -1267,12 +1267,12 @@ def check_args(args):
     if (args.service and
             (args.integrity or args.topology or args.custom)):
         if (args.dpath is None or args.dext is None):
-            log.info('With integrity or topology validation of a service' +
-                     ' we need to specify the path of the functions ' +
+            log.info('With integrity or topology validation of a service descriptor' +
+                     ' we need to specify the path of the function descriptors ' +
                      '(dpath) and the extension of it (dext)')
-            return {"error_message": "Need functions path " +
+            return {"error_message": "Need function descriptors path " +
                     "(dpath) and the extension of it (dext) to validate " +
-                    "service integrity|topology|custom_rules"}, 400
+                    "service descriptor integrity|topology|custom_rules"}, 400
 
     if (args.custom and args.source == 'local'):
         if (args.cfile is None):

--- a/src/tngsdk/validation/rest.py
+++ b/src/tngsdk/validation/rest.py
@@ -412,6 +412,7 @@ class Validation(Resource):
         args = validations_parser.parse_args()
         log.info("POST to /validation w. args: {}".format(args))
         check_correct_args = check_args(args)
+
         if check_correct_args is True:
             keypath, path = process_request(args)
             if not keypath or not path:

--- a/src/tngsdk/validation/schema/validator.py
+++ b/src/tngsdk/validation/schema/validator.py
@@ -45,7 +45,7 @@ class SchemaValidator(object):
     SCHEMA_PACKAGE_DESCRIPTOR = 'PD'
     SCHEMA_SERVICE_DESCRIPTOR = 'NSD'
     SCHEMA_FUNCTION_DESCRIPTOR = 'VNFD'
-
+    SCHEMA_TEST_DESCRIPTOR = 'TSTD'
     def __init__(self, workspace, preload=False):
         # Assign parameters
         coloredlogs.install(level=workspace.log_level)
@@ -87,6 +87,12 @@ class SchemaValidator(object):
                                       'function-descriptor/vnfd-schema.yml'),
                 'remote': self._schemas_remote_master +
                 '/function-descriptor/vnfd-schema.yml'
+            },
+            self.SCHEMA_TEST_DESCRIPTOR: {
+                'local': os.path.join(self._schemas_local_master,
+                                      'test-descriptor/test-schema.yml'),
+                'remote': self._schemas_remote_master +
+                '/test-descriptor/test-descriptor-schema.yml'
             }
         }
 
@@ -127,7 +133,8 @@ class SchemaValidator(object):
         """
         schemas = [self.SCHEMA_PACKAGE_DESCRIPTOR,
                    self.SCHEMA_SERVICE_DESCRIPTOR,
-                   self.SCHEMA_FUNCTION_DESCRIPTOR]
+                   self.SCHEMA_FUNCTION_DESCRIPTOR,
+                   self.SCHEMA_TEST_DESCRIPTOR]
 
         for schema in schemas:
             schema_file = self._schemas[schema]['local']
@@ -167,7 +174,6 @@ class SchemaValidator(object):
                 # Load schema from remote source
                 self._schemas_library[template] = \
                     load_remote_schema(schema_addr)
-
                 # Update the corresponding local schema file
                 write_local_schema(self._schemas_local_master,
                                    self._schemas[template]['local'],
@@ -215,7 +221,7 @@ class SchemaValidator(object):
             return True
 
         except ValidationError as e:
-            log.error("Failed to validate Descriptor against schema '{}'"
+            log.error("Failed to validate descriptor against schema '{}'"
                       .format(schema_id))
             self.error_msg = e.message
             log.error(e.message)

--- a/src/tngsdk/validation/storage.py
+++ b/src/tngsdk/validation/storage.py
@@ -1167,6 +1167,37 @@ class Function(Descriptor):
                 return True
             else:
                 return
+    def detect_selfloops(self):
+        """
+        detect wheter some vlink or vbridge are forming a loop
+        :return: the id of the vlink/vtree which makes the loop
+        """
+        selfloops = {}
+        for vl_id, vl in self.vlinks.items():
+            cpr_u = vl.cpr_u.split(":")
+            cpr_v = vl.cpr_v.split(":")
+            if cpr_u[0]==cpr_v[0]:
+                if vl_id not in selfloops.keys():
+                    selfloops[vl_id]=[vl.cpr_u,vl.cpr_v]
+                else:
+                    selfloops[vl_id].append([vl.cpr_u,vl.cpr_v])
+        for vb_id, vb in self.vbridges.items():
+            for i in range(0,len(vb.connection_point_refs)):
+                if vb_id in selfloops.keys():
+                    continue
+                cp = vb.connection_point_refs[i].split(":")
+                id = cp[0]
+                for j in range(0,len(vb.connection_point_refs)):
+                    if i==j:
+                        continue
+                    cp_aux = vb.connection_point_refs[j].split(":")
+                    id_aux = cp_aux[0]
+                    if id==id_aux:
+                        if vb_id not in selfloops.keys():
+                            selfloops[vb_id]=[vb.connection_point_refs[i],vb.connection_point_refs[j]]
+                        else:
+                            selfloops[vb_id].append(vb.connection_point_refs[j])
+        return selfloops
 
     def detect_disconnected_units(self):
         """

--- a/src/tngsdk/validation/storage.py
+++ b/src/tngsdk/validation/storage.py
@@ -134,7 +134,7 @@ class DescriptorStorage(object):
         :return: function descriptor object
         """
         if fid not in self._functions[fid]:
-            log.error("Function id='{0}' is not stored.".format(fid))
+            log.error("Function descriptor id='{0}' is not stored.".format(fid))
             return
         return self.functions[fid]
 
@@ -1186,7 +1186,6 @@ class Function(Descriptor):
                                       should be internally connected
         """
         graph = nx.Graph()
-
         def_node_attrs = {'label': '',
                           'level': level,
                           'parent_id': self.id,
@@ -1310,6 +1309,7 @@ class Function(Descriptor):
                         s_cpr = cpr
 
                     graph.add_edge(brnode, s_cpr, attr_dict={'label': vb_id})
+        
         return graph
 
     def undeclared_connection_points(self):

--- a/src/tngsdk/validation/storage.py
+++ b/src/tngsdk/validation/storage.py
@@ -54,6 +54,7 @@ class DescriptorStorage(object):
         self._services = {}
         self._functions = {}
         self._units = {}
+        self._tests = {}
 
     @property
     def packages(self):
@@ -78,7 +79,12 @@ class DescriptorStorage(object):
         :return: dictionary of functions.
         """
         return self._functions
-
+    @property
+    def tests(self):
+        """
+        Provides the stores tests
+        :return: dictionary of tests
+        """
     def service(self, sid):
         """
         Obtain the service for the provided service id
@@ -151,10 +157,36 @@ class DescriptorStorage(object):
         new_function = Function(descriptor_file)
         if new_function.id in self._functions.keys():
             return self._functions[new_function.id]
-
         self._functions[new_function.id] = new_function
         return new_function
 
+    def test(self, tid):
+        """
+        Obtain the function for the provided test id
+        :param tid: test id
+        :return: test descriptor object
+        """
+        if tid not in self._tests[tid]:
+            log.error("Test descriptor id='{0}' is not stored.".format(fid))
+            return
+        return self.functions[fid]
+
+    def create_test(self, descriptor_file):
+        """
+        Create and store a test based on the provided descriptor filename.
+        If a test is already stored with the same id, it will return the
+        stored test.
+        :param descriptor_file: test descriptor filename
+        :return: created test object or, if id exists, the stored test.
+        """
+        if not os.path.isfile(descriptor_file):
+            return
+        new_test = Test(descriptor_file)
+        if new_test.id in self._tests.keys():
+            return self._tests[new_test.id]
+
+        self._tests[new_test.id] = new_test
+        return new_test
 
 class Node:
     def __init__(self, nid):
@@ -353,6 +385,7 @@ class Descriptor(Node):
         This modification will impact the content and id of the descriptor.
         :param value: descriptor filename
         """
+
         self._filename = value
         content = read_descriptor_file(self._filename)
         if content:
@@ -1390,3 +1423,127 @@ class Unit(Node):
         :return: unit id
         """
         return self._id
+
+class Test_parameter:
+    def __init__(self, test_parameter):
+        self._parameter_name = test_parameter["parameter_name"]
+        self._parameter_definition = test_parameter["parameter_definition"]
+        self._parameter_value = test_parameter["parameter_value"]
+        self._content_type = test_parameter["content_type"]
+    @property
+    def parameter_name(self):
+        return self._parameter_name
+    @property
+    def parameter_definition(self):
+        return self._parameter_definition
+    @property
+    def parameter_value(self):
+        return self._parameter_value
+
+class Test_execution:
+    def __init__(self, test_execution):
+        self._tag_id = test_execution["tag_id"]
+        self._test_tag = test_execution["test_tag"]
+    @property
+    def test_id(self):
+        return self._test_id
+    @property
+    def test_tag(self):
+        return self._test_tag
+
+class Test:
+    def __init__(self, descriptor_file):
+        self._id = None
+        self._test_type = None
+        self._test_category = None
+        self._content = None
+        self.filename = descriptor_file
+        self._test_executions = []
+        self._test_configuration_parameters = []
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def test_type(self):
+        return self._test_type
+
+    @property
+    def test_category(self):
+        return self._test_category
+
+    @property
+    def content(self):
+        """
+        Descriptor dictionary.
+        :return: descriptor dict
+        """
+        return self._content
+
+    @property
+    def test_configuration_parameters(self):
+        return self._test_configuration_parameters
+
+    @property
+    def filename(self):
+        """
+        Filename of the descriptor
+        :return: descriptor filename
+        """
+        return self._filename
+
+    @property
+    def test_executions(self):
+        return self._test_executions
+
+    @content.setter
+    def content(self, value):
+        """
+        Sets the descriptor dictionary.
+        This modification will impact the id of the descriptor.
+        :param value: descriptor dict
+        """
+        self._content = value
+        self._id = descriptor_id(self._content)
+
+
+    @filename.setter
+    def filename(self, value):
+        """
+        Sets the descriptor filename.
+        This modification will impact the content and id of the descriptor.
+        :param value: descriptor filename
+        """
+        self._filename = value
+        content = read_descriptor_file(self._filename)
+        if content:
+            self.content = content
+
+    def set_test_type(self, test_type):
+        self._test_type = test_type
+
+    def set_test_category(self, test_category):
+        self._test_category = test_category
+
+    def add_test_configuration_parameter(self, test_conf_param):
+        """
+        :test_conf_param: Test_parameter object
+        """
+        self._test_configuration_parameters.append(test_conf_param)
+
+    def add_test_execution(self, test_execution):
+        """
+        :test_execution: Test_execution object
+        """
+        self._test_executions.append(test_execution)
+
+    def get_test_config_parameter(self, parameter_name):
+        """
+        :parameter_name: String
+        :return: The Test_parameter object which has that name if the name exists, None otherwise
+        """
+        for test_config_parameter in self._test_config_parameters:
+            if parameter_name in test_config_parameter:
+                 return self.add_test_configuration_parameters["parameter_name"]
+        return

--- a/src/tngsdk/validation/storage.py
+++ b/src/tngsdk/validation/storage.py
@@ -1200,7 +1200,7 @@ class Function(Descriptor):
                 return True
             else:
                 return
-    def detect_selfloops(self):
+    def detect_loops(self):
         """
         detect wheter some vlink or vbridge are forming a loop
         :return: the id of the vlink/vtree which makes the loop

--- a/src/tngsdk/validation/tests/test_unit_rest.py
+++ b/src/tngsdk/validation/tests/test_unit_rest.py
@@ -153,7 +153,6 @@ class TngSdkValidationRestTest(unittest.TestCase):
                           'firewall-vnfd.yml&source=local')
         data = r.data.decode('utf-8')
         d = json.loads(data)
-        print(r)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(d['result']['error_count'], 1)
         self.app.delete('/api/v1/validations')
@@ -215,7 +214,7 @@ class TngSdkValidationRestTest(unittest.TestCase):
         self.app.delete('/api/v1/validations')
         self.app.delete('/api/v1/resources')
     """
-    
+
     def test_rest_validation_service_topology_ok(self):
         r = self.app.post('/api/v1/validations?sync=true&syntax=true&' +
                           'integrity=true&topology=true&service=true' +
@@ -253,9 +252,10 @@ class TngSdkValidationRestTest(unittest.TestCase):
                           SAMPLES_DIR + 'samples/' +
                           'functions/valid-son/firewall-vnfd.yml')
         data = r.data.decode('utf-8')
+
         d = ast.literal_eval(data)
-        expected_message = ('Not possible to validate function and service ' +
-                            'and project in the same request')
+        expected_message = ('Not possible to validate function descriptor and service descriptor ' +
+                            'and project descriptor in the same request')
         self.assertEqual(d['error_message'], expected_message)
 
     def test_rest_validation_ko_no_path(self):
@@ -284,8 +284,8 @@ class TngSdkValidationRestTest(unittest.TestCase):
                           'samples/services/valid-son/valid.yml')
         data = r.data.decode('utf-8')
         d = ast.literal_eval(data)
-        expected_message = ('Need functions path (dpath) and the extension ' +
-                            'of it (dext) to validate service ' +
+        expected_message = ('Need function descriptors path (dpath) and the extension ' +
+                            'of it (dext) to validate service descriptor ' +
                             'integrity|topology|custom_rules')
         self.assertEqual(d['error_message'], expected_message)
 
@@ -332,7 +332,6 @@ class TngSdkValidationRestTest(unittest.TestCase):
         m = MultipartEncoder(data)
         headers = {'Content-Type': m.content_type}
         response = self.app.post(url, headers=headers, data=m)
-        print(response)
         self.assertEqual(response.status_code, 200)
 
     def test_rest_validation_ok_get_validations_by_id(self):

--- a/src/tngsdk/validation/util.py
+++ b/src/tngsdk/validation/util.py
@@ -55,7 +55,6 @@ def read_descriptor_files(files):
         descriptors[did] = file
     return descriptors
 
-
 def read_descriptor_file(file):
     """
     Reads a SONATA descriptor from a file.
@@ -63,10 +62,8 @@ def read_descriptor_file(file):
     :return: descriptor dictionary
     """
     with open(file, 'r') as _file:
-
         try:
             descriptor = yaml.load(_file)
-
         except yaml.YAMLError as exc:
             evtlog.log("Invalid descriptor",
                        "Error parsing descriptor file: {0}".format(exc),

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -1007,16 +1007,24 @@ class Validator(object):
         """
         log.info("Validating topology of function descriptor '{0}'"
                  .format(func.id))
-        """
         isolated_units = func.detect_disconnected_units()
         if isolated_units:
-            print("there are {} isolated_units".format(len(isolated_units)))
+            evtlog.log("Invalid toplogy graph",
+                        "{} isolated units were found in the topology"
+                        .format(len(loops)),
+                        func.id,
+                        "evt_vnfd_top_isolated_units")
             return
-        selfloops = func.detect_selfloops()
-        if selfloops:
-            print("there are {} vlinks/vbridges which are creating selfloop(s)".format(len(selfloops)))
+
+        loops = func.detect_loops()
+        if loops:
+            evtlog.log("Invalid toplogy graph",
+                        "{} loops were found in the topology"
+                        .format(len(loops)),
+                        func.id,
+                        "evt_vnfd_top_loops")
             return
-        """
+
         func.graph = func.build_topology_graph(bridges=True)
         if not func.graph:
             evtlog.log("Invalid topology graph",

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -999,6 +999,11 @@ class Validator(object):
         if isolated_units:
             print("there are {} isolated_units".format(len(isolated_units)))
             return
+        selfloops = func.detect_selfloops()
+        if selfloops:
+            print("there are {} vlinks/vbridges which are creating selfloop(s)".format(len(selfloops)))
+            return
+
         func.graph = func.build_topology_graph(bridges=True)
         if not func.graph:
             evtlog.log("Invalid topology graph",

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -43,11 +43,10 @@ import atexit
 import errno
 import yaml
 import inspect
-
+import matplotlib.pyplot as plt
 # Sonata and 55GTANGO imports
 from tngsdk.project.workspace import Workspace
 from tngsdk.project.project import Project
-
 from tngsdk.validation.storage import DescriptorStorage
 # from storage import DescriptorStorage
 # from son.validate.util import read_descriptor_files, list_files
@@ -387,7 +386,7 @@ class Validator(object):
         log.info("Validating topology of service descriptor '{0}'".format(service.id))
 
         # build service topology graph with VNF connection points
-        service.graph = service.build_topology_graph(level=1, bridges=False)
+        service.graph = service.build_topology_graph(level=1, bridges=True)
         if not service.graph:
             evtlog.log("Invalid topology",
                        "Couldn't build topology graph of service descriptor'{0}'"
@@ -898,7 +897,6 @@ class Validator(object):
         """
         log.info("Validating integrity of function descriptor '{0}'"
                  .format(func.id))
-
         # load function connection points
         if not func.load_connection_points():
             evtlog.log("Missing 'connection_points'",
@@ -988,7 +986,7 @@ class Validator(object):
 
     def _validate_function_topology(self, func):
         """
-        Validate the network topology of a function.
+        This functions validates the network topology of a function.
         It builds the topology graph of the function, including VDU
         connections.
         :param func: function to validate
@@ -997,7 +995,10 @@ class Validator(object):
         log.info("Validating topology of function descriptor '{0}'"
                  .format(func.id))
 
-        # build function topology graph
+        isolated_units = func.detect_disconnected_units()
+        if isolated_units:
+            print("there are {} isolated_units".format(len(isolated_units)))
+            return
         func.graph = func.build_topology_graph(bridges=True)
         if not func.graph:
             evtlog.log("Invalid topology graph",
@@ -1011,8 +1012,6 @@ class Validator(object):
                   .format(func.id, func.graph.edges()))
         log.info("Built topology graph of function descriptor'{0}': {1}"
                  .format(func.id, func.graph.edges()))
-
         return True
-
     def workspace(self):
         log.warning("workspace not implemented")

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -249,14 +249,14 @@ class Validator(object):
             if ((self._integrity or self._topology) and not
                     (self._dpath and self._dext)):
                 log.error("Invalid validation parameters. To validate the "
-                          "integrity, topology or custom rules of a service "
+                          "integrity, topology or custom rules of a service descriptors "
                           "both' --dpath' and '--dext' parameters must be "
                           "specified.")
                 return
             if ((self._custom) and not
                     (self._dpath and self._dext and self._cfile)):
                 log.error("Invalid validation parameters. To validate the "
-                          "custom rules of a service "
+                          "custom rules of a service descriptors"
                           "both' --dpath' and '--dext' parameters must be "
                           "specified (to validate the topology/integrity) and "
                           "'--cfile' must be specified")
@@ -298,7 +298,7 @@ class Validator(object):
             project = Project.load_project(project, workspace=self._workspace_path, translate=False)
         if type(project) is not Project:
             return
-        log.info("Validating project '{0}'".format(project.project_root))
+        log.info("Validating project descriptors'{0}'".format(project.project_root))
         log.info("... syntax: {0}, integrity: {1}, topology: {2}"
                  .format(self._syntax, self._integrity, self._topology))
 
@@ -309,7 +309,7 @@ class Validator(object):
             self._dpath.append(project_path + i)
         self._dext = project.descriptor_extension
         # load all project descriptors present at source directory
-        log.debug("Loading project service")
+        log.debug("Loading project service descriptor")
         nsd_file = Validator._load_project_service_file(project)
         if not nsd_file:
             return
@@ -355,7 +355,7 @@ class Validator(object):
         """
         if not self._assert_configuration():
             return
-        log.info("Validating service '{0}'".format(nsd_file))
+        log.info("Validating service descriptor '{0}'".format(nsd_file))
         log.info("... syntax: {0}, integrity: {1}, topology: {2}"
                  .format(self._syntax, self._integrity, self._topology))
         service = self._storage.create_service(nsd_file)
@@ -381,33 +381,33 @@ class Validator(object):
 
     def _validate_service_topology(self, service):
         """
-        Validate the network topology of a service.
+        Validate the network topology of a service descriptor.
         :return:
         """
-        log.info("Validating topology of service '{0}'".format(service.id))
+        log.info("Validating topology of service descriptor '{0}'".format(service.id))
 
         # build service topology graph with VNF connection points
         service.graph = service.build_topology_graph(level=1, bridges=False)
         if not service.graph:
             evtlog.log("Invalid topology",
-                       "Couldn't build topology graph of service '{0}'"
+                       "Couldn't build topology graph of service descriptor'{0}'"
                        .format(service.id),
                        service.id,
                        'evt_nsd_top_topgraph_failed')
             return
 
-        log.debug("Built topology graph of service '{0}': {1}"
+        log.debug("Built topology graph of service descriptor '{0}': {1}"
                   .format(service.id, service.graph.edges()))
 
         # write service graphs with different levels and options
         self.write_service_graphs(service)
 
         if nx.is_connected(service.graph):
-            log.debug("Topology graph of service '{0}' is connected"
+            log.debug("Topology graph of service descriptor '{0}' is connected"
                       .format(service.id))
         else:
             evtlog.log("Disconnected topology",
-                       "Topology graph of service '{0}' is disconnected"
+                       "Topology graph of service descriptor '{0}' is disconnected"
                        .format(service.id),
                        service.id,
                        'evt_nsd_top_topgraph_disconnected')
@@ -415,7 +415,7 @@ class Validator(object):
         # check if forwarding graphs section is available
         if 'forwarding_graphs' not in service.content:
             evtlog.log("Forwarding graphs not available",
-                       "No forwarding graphs available in service id='{0}'"
+                       "No forwarding graphs available in service descriptor id='{0}'"
                        .format(service.id),
                        service.id,
                        'evt_nsd_top_fwgraph_unavailable')
@@ -425,7 +425,7 @@ class Validator(object):
         # load forwarding graphs
         if not service.load_forwarding_graphs():
             evtlog.log("Bad section: 'forwarding_graphs'",
-                       "Couldn't load service forwarding graphs. ",
+                       "Couldn't load service descriptor forwarding graphs. ",
                        service.id,
                        'evt_nsd_top_badsection_fwgraph')
             return
@@ -644,11 +644,11 @@ class Validator(object):
         :param service: service to validate
         :return: True if syntax is correct, None otherwise
         """
-        log.info("Validating syntax of service '{0}'".format(service.id))
+        log.info("Validating syntax of service descriptor'{0}'".format(service.id))
         if not self._schema_validator.validate(
               service.content, SchemaValidator.SCHEMA_SERVICE_DESCRIPTOR):
             evtlog.log("Invalid NSD syntax",
-                       "Invalid syntax in service '{0}': {1}"
+                       "Invalid syntax in service descriptor'{0}': {1}"
                        .format(service.id, self._schema_validator.error_msg),
                        service.id,
                        'evt_nsd_stx_invalid')
@@ -666,7 +666,7 @@ class Validator(object):
         :return:
         """
 
-        log.info("Validating integrity of service '{0}'".format(service.id))
+        log.info("Validating integrity of service descriptor '{0}'".format(service.id))
         # get referenced function descriptors (VNFDs)
         if not self._load_service_functions(service):
             evtlog.log("Function not available",
@@ -678,7 +678,7 @@ class Validator(object):
         # validate service function descriptors (VNFDs)
         for fid, f in service.functions.items():
             if not self.validate_function(f.filename):
-                evtlog.log("Invalid function",
+                evtlog.log("Invalid function descriptor",
                            "Failed to validate function descriptor '{0}'"
                            .format(f.filename),
                            service.id,
@@ -688,7 +688,7 @@ class Validator(object):
         if not service.load_connection_points():
             evtlog.log("Bad section 'connection_points'",
                        "Couldn't load the connection points of "
-                       "service id='{0}'"
+                       "service descriptor id='{0}'"
                        .format(service.id),
                        service.id,
                        'evt_nsd_itg_badsection_cpoints')
@@ -696,7 +696,7 @@ class Validator(object):
         # load service links
         if not service.load_virtual_links():
             evtlog.log("Bad section 'virtual_links'",
-                       "Couldn't load virtual links of service id='{0}'"
+                       "Couldn't load virtual links of service descriptor id='{0}'"
                        .format(service.id),
                        service.id,
                        'evt_nsd_itg_badsection_vlinks')
@@ -738,7 +738,7 @@ class Validator(object):
                     func = service.mapped_function(s_cpr[0])
                     if not func or s_cpr[1] not in func.connection_points:
                         evtlog.log("Undefined connection point",
-                                   "Function (VNF) of vnf_id='{0}' declared "
+                                   "Function descriptor (VNFD) of vnf_id='{0}' declared "
                                    "in connection point '{0}' in virtual link "
                                    "'{1}' is not defined"
                                    .format(s_cpr[0], s_cpr[1], vl_id),
@@ -755,7 +755,7 @@ class Validator(object):
         :return: True if successful, None otherwise
         """
 
-        log.debug("Loading functions of the service.")
+        log.debug("Loading function descriptors of the service.")
         # # get VNFD file list from provided dpath
         if not self._dpath:
             return
@@ -771,14 +771,14 @@ class Validator(object):
 
         # check for errors
         if 'network_functions' not in service.content:
-            log.error("Service doesn't have any functions. "
+            log.error("Service descriptor doesn't have any functions. "
                       "Missing 'network_functions' section.")
             return
 
         functions = service.content['network_functions']
         if functions and not path_vnfs:
             evtlog.log("VNF not found",
-                       "Service references VNFs but none could be found in "
+                       "Service descriptor references VNFs but none could be found in "
                        "'{0}'. Please specify another '--dpath'"
                        .format(self._dpath),
                        service.id,
@@ -807,11 +807,11 @@ class Validator(object):
 
     def validate_function(self, vnfd_path):
         """
-        Validate one or multiple 5GTANGO functions (VNFs).
+        Validate one or multiple 5GTANGO functions (VNFs/CNFs).
         By default, it performs the following validations: syntax, integrity
         and network topology.
-        :param vnfd_path: function descriptor (VNFD) filename or
-                          a directory to search for VNFDs
+        :param function_path: function descriptor (VNFD/CNFD) filename or
+                          a directory to search for functions
         :return: True if all validations were successful, False otherwise
         """
         # if not self._assert_configuration():
@@ -819,9 +819,8 @@ class Validator(object):
 
         # validate multiple VNFs
         if os.path.isdir(vnfd_path):
-            log.info("Validating functions in path '{0}'".format(vnfd_path))
+            log.info("Validating function descriptors in path '{0}'".format(vnfd_path))
             vnfd_files = list_files(vnfd_path, self._dext)
-            # ANTON
             for vnfd_file in vnfd_files:
                 log.info("Detected file {0} order validation..."
                          .format(vnfd_file))
@@ -829,7 +828,7 @@ class Validator(object):
                     return
             return True
 
-        log.info("Validating function '{0}'".format(vnfd_path))
+        log.info("Validating function descriptor '{0}'".format(vnfd_path))
         log.info("... syntax: {0}, integrity: {1}, topology: {2},"
                  " custom: {3}"
                  .format(self._syntax, self._integrity, self._topology,
@@ -838,7 +837,7 @@ class Validator(object):
         func = self._storage.create_function(vnfd_path)
         if not func:
             evtlog.log("Invalid function descriptor",
-                       "Couldn't store VNF of file '{0}'".format(vnfd_path),
+                       "Couldn't store VNF/CNF of file '{0}'".format(vnfd_path),
                        vnfd_path,
                        'evt_function_invalid_descriptor')
             return
@@ -878,11 +877,11 @@ class Validator(object):
         :param func: function to validate
         :return: True if syntax is correct, None otherwise
         """
-        log.info("Validating syntax of function '{0}'".format(func.id))
+        log.info("Validating syntax of function descriptor '{0}'".format(func.id))
         if not self._schema_validator.validate(
                 func.content, SchemaValidator.SCHEMA_FUNCTION_DESCRIPTOR):
             evtlog.log("Invalid VNFD syntax",
-                       "Invalid syntax in function '{0}': {1}"
+                       "Invalid syntax in function descriptor'{0}': {1}"
                        .format(func.id, self._schema_validator.error_msg),
                        func.id,
                        'evt_vnfd_stx_invalid')
@@ -904,7 +903,7 @@ class Validator(object):
         if not func.load_connection_points():
             evtlog.log("Missing 'connection_points'",
                        "Couldn't load the connection points of "
-                       "function id='{0}'"
+                       "function descriptor id='{0}'"
                        .format(func.id),
                        func.id,
                        'evt_vnfd_itg_badsection_cpoints')
@@ -913,7 +912,7 @@ class Validator(object):
         # load units
         if not func.load_units():
             evtlog.log("Missing 'virtual_deployment_units or cloudnative_deployment_units'",
-                       "Couldn't load the units of function id='{0}'"
+                       "Couldn't load the units of function descriptor id='{0}'"
                        .format(func.id),
                        func.id,
                        'evt_vnfd_itg_badsection_vdus')
@@ -923,7 +922,7 @@ class Validator(object):
         if not func.load_unit_connection_points():
             evtlog.log("Bad section 'connection_points'",
                        "Couldn't load VDU connection points of "
-                       "function id='{0}'"
+                       "function descriptor id='{0}'"
                        .format(func.id),
                        func.id,
                        'evt_vnfd_itg_vdu_badsection_cpoints')
@@ -932,7 +931,7 @@ class Validator(object):
         # load function links
         if not func.load_virtual_links():
             evtlog.log("Bad section 'virtual_links'",
-                       "Couldn't load the links of function id='{0}'"
+                       "Couldn't load the links of function descriptor id='{0}'"
                        .format(func.id),
                        func.id,
                        'evt_vnfd_itg_badsection_vlinks')
@@ -956,7 +955,7 @@ class Validator(object):
             for cxpoint in unused_ifaces:
                 evtlog.log("{0} Unused connection point(s)"
                            .format(len(unused_ifaces)),
-                           "Function has unused connection points: {0}"
+                           "Function descriptor has unused connection points: {0}"
                            .format(cxpoint),
                            func.id,
                            'evt_vnfd_itg_unused_cpoint')
@@ -995,22 +994,22 @@ class Validator(object):
         :param func: function to validate
         :return: True if topology doesn't present issues
         """
-        log.info("Validating topology of function '{0}'"
+        log.info("Validating topology of function descriptor '{0}'"
                  .format(func.id))
 
         # build function topology graph
         func.graph = func.build_topology_graph(bridges=True)
         if not func.graph:
             evtlog.log("Invalid topology graph",
-                       "Couldn't build topology graph of function '{0}'"
+                       "Couldn't build topology graph of function descriptor '{0}'"
                        .format(func.id),
                        func.id,
                        'evt_vnfd_top_topgraph_failed')
             return
 
-        log.debug("Built topology graph of function '{0}': {1}"
+        log.debug("Built topology graph of function descriptor '{0}': {1}"
                   .format(func.id, func.graph.edges()))
-        log.info("Built topology graph of function '{0}': {1}"
+        log.info("Built topology graph of function descriptor'{0}': {1}"
                  .format(func.id, func.graph.edges()))
 
         return True

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -1019,13 +1019,14 @@ class Validator(object):
         loops = func.detect_loops()
         if loops:
             evtlog.log("Invalid toplogy graph",
-                        "{} loops were found in the topology"
+                        "{} loop(s) was/were found in the topology"
                         .format(len(loops)),
                         func.id,
                         "evt_vnfd_top_loops")
             return
-
-        func.graph = func.build_topology_graph(bridges=True)
+            
+        bridges = False
+        func.graph = func.build_topology_graph(bridges)
         if not func.graph:
             evtlog.log("Invalid topology graph",
                        "Couldn't build topology graph of function descriptor '{0}'"
@@ -1038,6 +1039,17 @@ class Validator(object):
                   .format(func.id, func.graph.edges()))
         log.info("Built topology graph of function descriptor'{0}': {1}"
                  .format(func.id, func.graph.edges()))
+
+        if not(bridges):
+            cycles = None
+            cycles = nx.cycle_basis(func.graph)
+            if cycles:
+                evtlog.log("Invalid topology graph",
+                           "{} cycle(s) was/were found in the topology"
+                           .format(len(cycles)),
+                           func.id,
+                           'evt_vnfd_top_cycles')
+                return
         return True
     def workspace(self):
         log.warning("workspace not implemented")


### PR DESCRIPTION
Now the validator can validate test descriptors in the following way:
- Validate a individual test descriptor tng-sdk-validate <validation level> --test <path/to/test>.
- Validate a folder with tests (the same syntax as before).
- Validate a project without NSD file. tng-sdk-validate <validation_level> --project <path/to/project>
- Validate a project with NSD and tests (the same syntax as before)