### PR TITLE
[#125] Validate only SONATA/5GTANGO descriptors

### DIFF
--- a/src/tngsdk/validation/eventcfg.yml
+++ b/src/tngsdk/validation/eventcfg.yml
@@ -14,7 +14,7 @@ evt_project_service_invalid: error
 evt_project_service_multiple: error
 
 # Project - there are not descriptors
-evt_project_no_descriptors: error
+evt_project_no_descriptors: warning
 
 ### PACKAGE
 

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -335,18 +335,15 @@ class Validator(object):
             return self.validate_service(nsd_file) and descriptors_ok
         elif not(nsd_file) and descriptors_files:
             return descriptors_ok
-        else:
+        elif nsd_file and not(descriptor_files):
             nsd_file = project_path + nsd_file
             return self.validate_service(nsd_file)
-        """
-        elif not(nsd_file) and not(descriptors_files):
+        else:
             evtlog.log("No descriptors",
                        "There are not descriptors in this project ",
                        project.project_root,
                        'evt_project_no_descriptors')
             return False
-        """
-
 
     @staticmethod
     def _load_project_service_file(project):

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -335,7 +335,7 @@ class Validator(object):
             return self.validate_service(nsd_file) and descriptors_ok
         elif not(nsd_file) and descriptors_files:
             return descriptors_ok
-        elif nsd_file and not(descriptor_files):
+        elif nsd_file and not(descriptors_files):
             nsd_file = project_path + nsd_file
             return self.validate_service(nsd_file)
         else:


### PR DESCRIPTION
Now the validator ignores the descriptors which do not belong to SONATA/5GTANGO