### PR TITLE
[#106] Change isolated units error

### DIFF
--- a/src/tngsdk/validation/eventcfg.yml
+++ b/src/tngsdk/validation/eventcfg.yml
@@ -109,7 +109,7 @@ evt_nsd_top_topgraph_unnused_cps_vnfd: warning
 evt_nsd_top_topgraph_loops_in_vnfd: error
 
 # NSD [topology] - there are disconnected vnfd (all cp unnused)
-evt_nsd_top_topgraph_isolated_vnfd: error
+evt_nsd_top_topgraph_isolated_vnfd: warning
 ## FUNCTION
 
 # Function - invalid descriptor file
@@ -149,7 +149,7 @@ evt_vnfd_itg_duplicated_ports_in_CDUs: error
 evt_vnfd_top_topgraph_failed: error
 
 # VNFD [topology] - isolated units were detected
-evt_vnfd_top_isolated_units: error
+evt_vnfd_top_isolated_units: warning
 
 # VNFD [topology] - unnused connection points in units were detected
 evt_vnfd_top_unnused_cps_unit: warning

--- a/src/tngsdk/validation/validator.py
+++ b/src/tngsdk/validation/validator.py
@@ -811,7 +811,6 @@ class Validator(object):
             vnfd_files = list_files(self._dpath, self._dext)
             log.debug("Found {0} descriptors in dpath='{2}': {1}"
                       .format(len(vnfd_files), vnfd_files, self._dpath))
-
         # load all VNFDs
         path_vnfs = read_descriptor_files(vnfd_files)
 
@@ -830,7 +829,6 @@ class Validator(object):
                        service.id,
                        'evt_nsd_itg_function_unavailable')
             return
-
         # store function descriptors referenced in the service
         for func in functions:
             fid = build_descriptor_id(func['vnf_vendor'],


### PR DESCRIPTION
There was a topology error called "isolated units" (i.e. all CP disconnected). If there were not CP in the units (CNFD/VNFD) this error would arise always. Now, we change the error and the validator will show a warning which does not break the validation.